### PR TITLE
Properly commented lang files to fix Cauldron issue.

### DIFF
--- a/src/main/resources/assets/bloodutils/lang/en_US.lang
+++ b/src/main/resources/assets/bloodutils/lang/en_US.lang
@@ -1,4 +1,4 @@
-==Items==
+#==Items==
 item.ritual sigil.name=Ritual Sigil
 item.advanced divination sigil.name=Advanced Divination Sigil
 item.creative tool.name=Creative Tool
@@ -14,7 +14,7 @@ item.empty gem.name=Elemental Gem Casing
 item.blood diamond.name=Blood Diamond
 item.blood iron ingot.name=Blood Diamond Ingot
 item.royal blood shard.name=Royal Blood Shard
-==Blocks==
+#==Blocks==
 tile.altar progression checker.name=Divination Block
 tile.altar builder.name=Altar Builder
 tile.blood diamond block.name=Blood Diamond Block
@@ -29,9 +29,9 @@ tile.area rainbow.name=Magic Ritual: Rainbow
 tile.earth block.name=Earth Block
 tile.discoball.name=Discoball
 tile.discoball stairs.name=Disco Stairs
-==Entities==
+#==Entities==
 entity.BloodUtils.royal.name=Royal
-==Entries==
+#==Entries==
 bu.entry.Blood Altar.1=The altar is the first thing you most likely want to make in blood magic, it's the base of everything. You need a sacrificial knife/orb to fill it up.
 bu.entry.Runes.1=The Rune of Self-Sacrifice is a rune which increases the amount of essence you get for sacrificing yourself by 10 percent.
 bu.entry.Runes.2=The Rune of Sacrifice is a rune which increases the amount of essence you get from mobs by 10 percent.
@@ -67,5 +67,5 @@ bu.entry.Elemental Rituals.1=These blocks are capable of storing a whole (small)
 bu.entry.Elemental Rituals.2=These so called Elemental Rituals exist out of a three components, two of these area already discovered. One of the three components is the Empty Gem Casing. The second Component is a blood diamond, forged from blood and a diamond. The third component still remains to be found.
 bu.entry.Debug.1=Blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah.
 bu.entry.Debug.2=Yes Altar Tier explaination will come later :).
-==Misc==
+#==Misc==
 itemGroup.tabBloodUtilsMain=Blood Utils: Main

--- a/src/main/resources/assets/bloodutils/lang/zh_CN.lang
+++ b/src/main/resources/assets/bloodutils/lang/zh_CN.lang
@@ -1,12 +1,12 @@
-==Items==
+#==Items==
 item.ritual sigil.name=仪式印记
 item.advanced divination sigil.name=进阶占卜印记
 item.creative tool.name=无限LP工具
 item.blood tome.name=血之卷轴
-==Blocks==
+#==Blocks==
 tile.altar progression checker.name=占卜符文
 tile.altar builder.name=祭坛搭建器
-==Entries==
+#==Entries==
 bu.entry.Blood Altar.1=要成为血魔法使就必须先拥有血祭坛, 它是最基础的工具. 你需要用牺牲匕首或牺牲宝珠来向祭坛灌输你的血.
 bu.entry.Runes.1=为你的血祭坛装上牺牲符文, 通过牺牲匕首灌输的生命源质将增加10%.
 bu.entry.Runes.2=为你的血祭坛装上献祭符文, 通过献祭匕首灌输的生命源质将增加10%.
@@ -39,5 +39,5 @@ bu.entry.Eternal Soul.1=永魂之泣仪式必须配合4级血祭坛使用. 当�
 bu.entry.Eternal Soul.2=除此之外, 被传输的LP会首先积攒在血祭坛的缓存区, 这就代表着你可以使用一些符文来使传输的LP增值, 例如牺牲符文. 另外, 如果你的生命值被永魂之泣仪式消耗到仅剩1颗心, 那么仪式将不再运作. 请确保你呆在安全的地方进行献祭!
 bu.entry.Curing.1=治愈仪式能消除玩家携有的一切负面效果, 就像牛奶那样.
 bu.entry.Debug.1=滴滴哒哒...滴滴哒哒...滴滴哒哒...滴滴哒哒...滴滴哒哒...滴滴哒哒...滴滴哒哒....
-==Misc==
+#==Misc==
 itemGroup.tabBloodUtilsMain=Blood Utils


### PR DESCRIPTION
I've had this issue before, with Electro-Magic Tools. 

The problem only occurs with Cauldron, the lang files will show up in chat like this because reasons:
![](http://i.imgur.com/JO4KnIH.png)

I would link to the Cauldron issue, but the Cauldron github no longer exists. Even though Cauldron has been DMCA'd there are still plenty of people that use it.

If you need a second opinion before accepting this PR, ask https://github.com/Tombenpotter.
